### PR TITLE
Added support for Events in the Past

### DIFF
--- a/custom_components/anniversaries/sensor.py
+++ b/custom_components/anniversaries/sensor.py
@@ -164,6 +164,9 @@ class anniversaries(Entity):
         if today > nextDate:
             nextDate = self._date.date() + relativedelta(year=today.year + 1)
             years = years + 1
+            daysRemaining = (today - self._date.date()).days
+        else:
+            daysRemaining = (nextDate - today).days
 
         daysRemaining = (nextDate - today).days
 


### PR DESCRIPTION
Now, a one-Time Event in the Past will be counted as Days after the Event