### PR TITLE
Add Next Date Attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ anniversaries:
 * years at next anniversary: number of years that will have passed at the next occurrence _(NOT displayed if year is unknown)_
 * current years: number of years have passed since the first occurance (ie, current age)  _(NOT displayed if year is unknown)_
 * date:  The date of the first occurence _(or the date of the next occurence if year is unknown)_
+* next_date: The date of the next occurance
 * weeks_remaining: The number of weeks until the anniversary
 * unit_of_measurement: 'Days' By default, this is displayed after the state. _this is NOT translate-able.  See below for work-around_
 * half_anniversary_date: The date of the next half anniversary (if enabled by `show_half_anniversary`)

--- a/custom_components/anniversaries/sensor.py
+++ b/custom_components/anniversaries/sensor.py
@@ -31,6 +31,7 @@ from .const import (
 ATTR_YEARS_NEXT = "years_at_next_anniversary"
 ATTR_YEARS_CURRENT = "current_years"
 ATTR_DATE = "date"
+ATTR_NEXT_DATE = "next_date"
 ATTR_WEEKS = "weeks_remaining"
 ATTR_HALF_DATE = "half_anniversary_date"
 ATTR_HALF_DAYS = "days_until_half_anniversary"
@@ -117,6 +118,7 @@ class anniversaries(Entity):
             res[ATTR_YEARS_NEXT] = self._years_next
             res[ATTR_YEARS_CURRENT] = self._years_current
         res[ATTR_DATE] = self._date
+        res[ATTR_NEXT_DATE] = self._next_date
         res[ATTR_WEEKS] = self._weeks_remaining
         if self._show_half_anniversary:
             res[ATTR_HALF_DATE] = self._half_date
@@ -161,6 +163,8 @@ class anniversaries(Entity):
             if today > nextDate:
                 nextDate = self._date.date() + relativedelta(year=today.year + 1)
 
+        self._next_date = datetime.combine(nextDate, datetime.min.time())
+        self._next_date = self._next_date.replace(tzinfo=dt_util.DEFAULT_TIME_ZONE)
         daysRemaining = (nextDate - today).days
         
         if self._unknown_year:

--- a/info.md
+++ b/info.md
@@ -23,6 +23,7 @@ Attributes:
 * years at next anniversary: number of years that will have passed at the next occurrence  _(NOT displayed if year is unknown)_
 * current years: number of years have passed since the first occurance (ie, current age)  _(NOT displayed if year is unknown)_
 * date:  The date of the first occurence _(or the date of the next occurence if year is unknown)_
+* next_date: The date of the next occurance
 * weeks_remaining: The number of weeks until the anniversary
 * unit_of_measurement: 'Days' By default, this is displayed after the state. _this is NOT translate-able.  See below for work-around_
 * half_anniversary_date: The date of the next half anniversary (if enabled by `show_half_anniversary`)


### PR DESCRIPTION
First of all - great custom component! We've been having fun adding birthdays, anniversaries, and even the start of the first day of school to our Home Assistant install. 

This PR adds an additional attribute `next_date` to the sensor. This will be the date of the next occurrence for the date given. It uses the value calculated when setting up the sensor and just saves it for adding to the attributes when that function is called. I had a need for this and saw it was a requested feature in #108 as well. 

### Usefulness

As a use case for this I've been trying to write a template sensor to bring up the next anniversary entered by gathering them all and sorting them. There are UI elements to do this but I wanted it in a sensor. I encountered an issue given that the `sort` template filter won't treat the state of the sensor as an int, in HA it's a string. This made sorting by the state unusable and there was no other attribute available that would give me a good ordering of the sensors. By having the `next_date` attribute available this can be used in the template to sort everything and get the next occurring item easily. Below is my example template: 

_Note, my sensors all start with "birthday"_
```
{% set birthdays = states.sensor | selectattr('entity_id', 'match', 'sensor.birthday_*') | 
   sort(attribute="attributes.next_date") %}
{% if birthdays | length > 0 %}
{% set b = birthdays[0] %}
{{ b.attributes.friendly_name }} is in {{ b.state }} {{ b.attributes.unit_of_measurement | lower }}
{% endif %}
```