### PR TITLE
rename years_at_anniversary and alter logic

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ anniversaries:
 
 ### Attributes
 
-* years at next anniversary: number of years that will have passed at the next occurrence _(NOT displayed if year is unknown)_
+* years at anniversary: number of years that will have passed at the occurrence counted down to _(NOT displayed if year is unknown)_
 * current years: number of years have passed since the first occurance (ie, current age)  _(NOT displayed if year is unknown)_
 * date:  The date of the first occurence _(or the date of the next occurence if year is unknown)_
 * next_date: The date of the next occurance

--- a/custom_components/anniversaries/sensor.py
+++ b/custom_components/anniversaries/sensor.py
@@ -38,7 +38,7 @@ from .const import (
     CALENDAR_NAME,
 )
 
-ATTR_YEARS_NEXT = "years_at_next_anniversary"
+ATTR_YEARS_NEXT = "years_at_anniversary"
 ATTR_YEARS_CURRENT = "current_years"
 ATTR_DATE = "date"
 ATTR_NEXT_DATE = "next_date"
@@ -189,7 +189,10 @@ class anniversaries(Entity):
             self._icon = self._icon_normal
 
         self._state = daysRemaining
-        self._years_next = years
+        if daysRemaining == 0:
+            self._years_next = years - 1
+        else:
+            self._years_next = years
         self._years_current = years - 1
         self._weeks_remaining = int(daysRemaining / 7)
 

--- a/info.md
+++ b/info.md
@@ -22,7 +22,7 @@ State Returned:
 
 Attributes:
 
-* years at next anniversary: number of years that will have passed at the next occurrence  _(NOT displayed if year is unknown)_
+* years at anniversary: number of years that will have passed at the occurrence counted down to _(NOT displayed if year is unknown)_
 * current years: number of years have passed since the first occurance (ie, current age)  _(NOT displayed if year is unknown)_
 * date:  The date of the first occurence _(or the date of the next occurence if year is unknown)_
 * next_date: The date of the next occurance


### PR DESCRIPTION
Years at next anniversary is ambiguous, as on the day of the anniversary is 0 (still counting down to today), but years_at_next_anniversary is the only attribute now referring to the following anniversary, so makes no sense. This renames the attribute and relates to the anniversary counted towards

closes #119 