### PR TITLE
Add dynamic services to Anniversaries component to add and remove ann…

### DIFF
--- a/custom_components/anniversaries/__init__.py
+++ b/custom_components/anniversaries/__init__.py
@@ -15,6 +15,8 @@ from .const import (
     CONFIG_SCHEMA,
 )
 
+from .services import async_register_services
+
 _LOGGER = logging.getLogger(__name__)
 
 async def async_setup(hass, config):
@@ -27,6 +29,9 @@ async def async_setup(hass, config):
     _LOGGER.info(
         CC_STARTUP_VERSION.format(name=DOMAIN, version=VERSION, issue_link=ISSUE_URL)
     )
+
+    # Register services
+    await async_register_services(hass)
 
     platform_config = config[DOMAIN].get(CONF_SENSORS, {})
 
@@ -60,6 +65,9 @@ async def async_setup_entry(hass, config_entry):
     _LOGGER.info(
         CC_STARTUP_VERSION.format(name=DOMAIN, version=VERSION, issue_link=ISSUE_URL)
     )
+
+    # Register services
+    await async_register_services(hass)
 
     # Safely update entry options if needed
     hass.config_entries.async_update_entry(

--- a/custom_components/anniversaries/services.py
+++ b/custom_components/anniversaries/services.py
@@ -1,0 +1,153 @@
+"""Dynamic services for Anniversaries integration."""
+import logging
+from typing import Any, Dict
+
+import voluptuous as vol
+from homeassistant.core import HomeAssistant, ServiceCall
+from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.data_entry_flow import FlowResultType
+
+from .const import (
+    DOMAIN,
+    CONF_NAME,
+    CONF_DATE,
+    CONF_DATE_TEMPLATE,
+    CONF_ONE_TIME,
+    CONF_COUNT_UP,
+    CONF_UNIT_OF_MEASUREMENT,
+    CONF_ID_PREFIX,
+)
+
+_LOGGER = logging.getLogger(__name__)
+
+# Service schema for adding an anniversary
+ADD_ANNIVERSARY_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+    vol.Exclusive(CONF_DATE, 'date_specifier'): cv.string,
+    vol.Exclusive(CONF_DATE_TEMPLATE, 'date_specifier'): cv.template,
+    vol.Optional(CONF_ONE_TIME, default=False): cv.boolean,
+    vol.Optional(CONF_COUNT_UP, default=False): cv.boolean,
+    vol.Optional(CONF_UNIT_OF_MEASUREMENT): cv.string,
+    vol.Optional(CONF_ID_PREFIX): cv.string,
+})
+
+# Service schema for removing an anniversary
+REMOVE_ANNIVERSARY_SCHEMA = vol.Schema({
+    vol.Required(CONF_NAME): cv.string,
+})
+
+async def async_register_services(hass: HomeAssistant):
+    """Register services for the Anniversaries integration."""
+
+    async def add_anniversary(call: ServiceCall) -> None:
+        """Service to add a new anniversary."""
+        # Prepare anniversary configuration
+        anniversary_config = {
+            CONF_NAME: call.data[CONF_NAME],
+        }
+
+        # Add date or date template
+        if CONF_DATE in call.data:
+            anniversary_config[CONF_DATE] = call.data[CONF_DATE]
+        elif CONF_DATE_TEMPLATE in call.data:
+            anniversary_config[CONF_DATE_TEMPLATE] = call.data[CONF_DATE_TEMPLATE]
+        else:
+            raise HomeAssistantError("Either date or date template must be provided")
+
+        # Add optional parameters
+        optional_params = [
+            CONF_ONE_TIME,
+            CONF_COUNT_UP,
+            CONF_UNIT_OF_MEASUREMENT,
+            CONF_ID_PREFIX,
+        ]
+        for param in optional_params:
+            if param in call.data:
+                anniversary_config[param] = call.data[param]
+
+        # Create a user configuration flow
+        flow = await hass.config_entries.flow.async_init(
+            DOMAIN,
+            context={'source': 'user'},
+            data=anniversary_config
+        )
+
+        # Handle multi-step config flow
+        while flow['type'] == FlowResultType.FORM:
+            # Prepare data for the next step
+            step_id = flow['step_id']
+
+            if step_id == 'icons':
+                # Provide default icon configuration
+                icon_config = {
+                    'icon_normal': 'mdi:calendar-blank',
+                    'icon_today': 'mdi:calendar-star',
+                    'icon_soon': 'mdi:calendar',
+                    'days_as_soon': 1
+                }
+
+                flow = await hass.config_entries.flow.async_configure(
+                    flow['flow_id'],
+                    user_input=icon_config
+                )
+            else:
+                # If an unexpected step occurs, raise an error
+                raise HomeAssistantError(f"Unexpected config flow step: {step_id}")
+
+        # Check if the flow was successful
+        if flow['type'] != FlowResultType.CREATE_ENTRY:
+            raise HomeAssistantError(f"Failed to create anniversary: {flow}")
+
+    async def remove_anniversary(call: ServiceCall) -> None:
+        """Service to remove an anniversary by name."""
+        name = call.data[CONF_NAME]
+
+        # Get all config entries for this domain
+        entries = hass.config_entries.async_entries(DOMAIN)
+
+        # Get the entity registry
+        registry = er.async_get(hass)
+
+        # Track if any anniversary was removed
+        removed = False
+
+        # Check each config entry
+        for config_entry in entries:
+            # Find entities for this config entry
+            entities = er.async_entries_for_config_entry(registry, config_entry.entry_id)
+
+            # Remove matching entities and config entry
+            for entity in entities:
+                if entity.original_name == name:
+                    # Remove the entity from the registry
+                    registry.async_remove(entity.entity_id)
+
+                    # Remove the config entry
+                    await hass.config_entries.async_remove(config_entry.entry_id)
+                    removed = True
+                    break
+
+            if removed:
+                break
+
+        if not removed:
+            raise HomeAssistantError(f"No anniversary found with name: {name}")
+
+    # Register services with validation schemas
+    hass.services.async_register(
+        DOMAIN,
+        'add_anniversary',
+        add_anniversary,
+        schema=ADD_ANNIVERSARY_SCHEMA
+    )
+
+    hass.services.async_register(
+        DOMAIN,
+        'remove_anniversary',
+        remove_anniversary,
+        schema=REMOVE_ANNIVERSARY_SCHEMA
+    )
+
+    _LOGGER.info("Anniversaries dynamic services registered")

--- a/custom_components/anniversaries/services.yaml
+++ b/custom_components/anniversaries/services.yaml
@@ -1,0 +1,58 @@
+# services.yaml for Anniversaries integration
+add_anniversary:
+  description: Adds a new anniversary to Home Assistant.
+  fields:
+    name:
+      description: Name of the anniversary.
+      example: "Wedding Anniversary"
+      required: true
+      selector:
+        text:
+    date:
+      description: Date of the anniversary in YYYY-MM-DD or MM-DD format.
+      example: "2020-06-20"
+      required: false
+      selector:
+        text:
+    date_template:
+      description: Template to determine the anniversary date.
+      example: "{{ states('input_text.anniversary_date') }}"
+      required: false
+      selector:
+        template:
+    one_time:
+      description: Whether this is a one-time event that doesn't repeat annually.
+      default: false
+      required: false
+      selector:
+        boolean:
+    count_up:
+      description: Whether to count up from the date instead of down to the next occurrence.
+      default: false
+      required: false
+      selector:
+        boolean:
+    unit_of_measurement:
+      description: Unit of measurement for the sensor.
+      example: "days"
+      default: "days"
+      required: false
+      selector:
+        text:
+    id_prefix:
+      description: Prefix to use for the entity ID.
+      example: "anniversary_"
+      default: "anniversary_"
+      required: false
+      selector:
+        text:
+
+remove_anniversary:
+  description: Removes an anniversary from Home Assistant.
+  fields:
+    name:
+      description: Name of the anniversary to remove.
+      example: "Wedding Anniversary"
+      required: true
+      selector:
+        text:


### PR DESCRIPTION
## Description

This PR adds two new dynamic services to the Anniversaries integration:

- `anniversaries.add_anniversary`: Creates a new anniversary dynamically via service call
- `anniversaries.remove_anniversary`: Removes an existing anniversary by name

This feature enables creating and managing anniversaries through automations without requiring UI configuration or restarts.

## Changes

- Added a new `services.py` module with service registration and handlers
- Added a `services.yaml` file with service descriptions and schema
- Updated `__init__.py` to register the services during setup